### PR TITLE
Remove consumer from my_gcp_function_project

### DIFF
--- a/projects/my_gcp_function_project/pyproject.toml
+++ b/projects/my_gcp_function_project/pyproject.toml
@@ -14,9 +14,6 @@ dependencies = [
   "functions-framework~=3.5.0",
 ]
 
-[project.scripts]
-consumer = "example.consumer.core:main"
-
 [tool.hatch.build.force-include]
 "main.py" = "main.py" # added by the build process
 "requirements.txt" = "requirements.txt" # added by the build process


### PR DESCRIPTION
It depends on the unresolved consumer, maybe from consumer_project.
This is to make it consistent with https://github.com/DavidVujic/python-polylith-example/blob/0f9c3da40bbe439bae8045fa65569edae23627c3/projects/my_gcp_function_project/pyproject.toml
Similar to DavidVujic/python-polylith-example-hatch#2